### PR TITLE
Correct destination boards

### DIFF
--- a/src/stationBoard.js
+++ b/src/stationBoard.js
@@ -148,7 +148,7 @@ class StationBoard {
                     }
 
                     if (locationRecord['location']) {
-                        this.board[i][boardKey].push(locationRecord['location'][0]['name']);
+                        this.board[i][boardKey].push(helper.toProperCase(locationRecord['location'][0]['name']));
                     }
                 }
             }

--- a/src/stationBoard.js
+++ b/src/stationBoard.js
@@ -138,7 +138,8 @@ class StationBoard {
         tiplocList.forEach((journey, j) => {
             if(journey !== undefined) {
                 const tiplocs = journey.map(record => {return record['tiploc']});
-                if(tiplocs.includes(this.tiploc)) {
+                const intersection = this.tiploc.filter(value => -1 !== tiplocs.indexOf(value));
+                if(intersection.length > 0) {
                     let locationRecord;
                     if (this.direction == d.ARRIVALS) {
                         locationRecord = journey.shift();

--- a/src/stationBoard.js
+++ b/src/stationBoard.js
@@ -163,7 +163,7 @@ class StationBoard {
         const publicTimeKey = (this.direction == d.ARRIVALS) ?  'public_arrival' : 'public_departure';
         const recordTiploc = record['tiploc'];
 
-        if(this.tiploc.includes(recordTiploc) && record[publicTimeKey] !== undefined) {
+        if(this.tiploc.includes(recordTiploc) && record[publicTimeKey] !== undefined && record[publicTimeKey] !== null) {
             this.board[i][publicTimeKey] = record[publicTimeKey];
             this.board[i][publicTimeKey] = DateTime.fromFormat(record[publicTimeKey], 'HH:mm:ss')
                                                         .toFormat('HH:mm');

--- a/src/stationBoard.js
+++ b/src/stationBoard.js
@@ -30,6 +30,7 @@ class StationBoard {
     createBoard() {
         this.schedules.forEach((schedule, i) => {
             try {
+                let tiplocList = this.reconstructFullJourney(schedule);
                 this.board.push({});
 
                 this.getJourneyOperator(schedule, i);
@@ -39,7 +40,6 @@ class StationBoard {
                 if(schedule['location_records'] !== undefined) {
                     schedule['location_records'].forEach(record => {
                         this.getJourneyPlatform(record, i);
-                        this.getJourneyLocation(record, i);
                         this.getJourneyPublicTime(record, i);
                         this.getJourneyPredictedTime(record, i);
                         this.getJourneyActualTime(record, i);
@@ -47,13 +47,8 @@ class StationBoard {
                     });
                 }
 
-                if(schedule['associations'] !== undefined) {
-                    schedule['associations'].forEach(assocSchedule => {
-                        assocSchedule['location_records'].forEach(assocScheduleRecord => {
-                            this.getJourneyLocation(assocScheduleRecord, i);
-                        });
-                    });
-                }
+                this.getJourneyLocation(tiplocList, i);
+
             } catch (error) {
                 let err = new Error(`${error.message} | Error for schedule ${schedule['uid']}`);
                 err.schedule = schedule;
@@ -62,6 +57,52 @@ class StationBoard {
         });
 
         return this.board;
+    }
+
+    reconstructFullJourney(schedule) {
+        let journeys = [];
+        if(schedule['associations'] !== undefined && schedule['location_records'] !== undefined) {
+            let actvityPoint = {};
+            for (let i = 0; i < schedule['associations'].length; i++) {
+                const association = schedule['associations'][i];
+                journeys.push(association['location_records']);
+                for (let j = 0; j < association['location_records'].length; j++) {
+                    const assocRecord = association['location_records'][j];
+                    
+                    for (let k = 0; k < schedule['location_records'].length; k++) {
+                        const record = schedule['location_records'][k];
+                        if (record['tiploc'] == assocRecord['tiploc']) {
+                            actvityPoint = record;
+                        }
+                    }
+                }
+            }
+
+            journeys = journeys.map(journey => {
+                let index = journey.findIndex(record => {
+                    return record['tiploc'] == actvityPoint['tiploc'];
+                });
+
+                if (index === 0) { // A Splitter
+                    let otherIndex = schedule['location_records'].findIndex(record => {
+                        return record['tiploc'] == actvityPoint['tiploc'];
+                    });
+                    let missingRecords = schedule['location_records'].slice(0, otherIndex);
+                    missingRecords.forEach(record => journey.unshift(record));
+                } else { // A Joiner
+                    // let otherIndex = schedule['location_records'].findIndex(record => {
+                    //     return record['tiploc'] == actvityPoint['tiploc'];
+                    // });
+                    // let missingRecords = schedule['location_records'].slice(0, otherIndex);
+                    // journey.unshift(missingRecords);
+                }
+
+                return journey;
+            });
+            
+        }
+        journeys.push(schedule['location_records']);
+        return journeys;
     }
 
     getJourneyOperator(schedule, i) {
@@ -91,20 +132,29 @@ class StationBoard {
 
     }
 
-    getJourneyLocation(record, i) {
-        const recordType = (this.direction == d.ARRIVALS) ?  'LO' : 'LT';
-        const locationKey = (this.direction == d.ARRIVALS) ?  'origin' : 'destination';
+    getJourneyLocation(tiplocList, i) {
+        const boardKey = (this.direction == d.ARRIVALS) ?  'origin' : 'destination';
+        this.board[i][boardKey] = [];
+        tiplocList.forEach((journey, j) => {
+            if(journey !== undefined) {
+                const tiplocs = journey.map(record => {return record['tiploc']});
+                if(tiplocs.includes(this.tiploc)) {
+                    let locationRecord;
+                    if (this.direction == d.ARRIVALS) {
+                        locationRecord = journey.shift();
+                    } else {
+                        locationRecord = journey.pop();
+                    }
 
-        if(record['type'] === recordType) {
-            if (typeof(this.board[i][locationKey]) === 'string') {
-                const currentLocation = this.board[i][locationKey];
-                this.board[i][locationKey] = [currentLocation];
-                this.board[i][locationKey].push(helper.toProperCase(record['location'][0]['name']));
-            } else if (Array.isArray(this.board[i][locationKey])) {
-                this.board[i][locationKey].push(helper.toProperCase(record['location'][0]['name']));
-            } else {
-                this.board[i][locationKey] = helper.toProperCase(record['location'][0]['name']);
+                    if (locationRecord['location']) {
+                        this.board[i][boardKey].push(locationRecord['location'][0]['name']);
+                    }
+                }
             }
+        });
+
+        if (this.board[i][boardKey].length === 1) {
+            this.board[i][boardKey] = this.board[i][boardKey][0];
         }
     }
 

--- a/test/stationBoard.test.js
+++ b/test/stationBoard.test.js
@@ -127,7 +127,7 @@ describe('Station Boards', function() {
     describe('Departures', () => {
         
         describe('Destination', () => {
-            it('should contain a single destination', () => {
+            it('should contain a single destination when there is no assoication(s)', () => {
                 const schedules = [
                     {'location_records': [
                         {'tiploc': 'ABCDEF', 'type': 'LO', location: [{'name': 'Station 1'}]},
@@ -144,7 +144,7 @@ describe('Station Boards', function() {
                 expect(board[0]['destination']).to.equal('Station 3');
             });
 
-            it('should contain an array of destinations if there is one association', () => {
+            it('should contain two destinations if there is one association and the board is before the split', () => {
                 const schedules = [
                     {'location_records': [
                         {'tiploc': 'ABCDEF', 'type': 'LO', location: [{'name': 'Station 1'}]},
@@ -153,7 +153,7 @@ describe('Station Boards', function() {
                         ],
                     'associations': [
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 4'}]},
                             {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 5'}]},
                             ],
@@ -161,7 +161,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.DEPARTURES, 'ABCDEF')
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -170,7 +170,59 @@ describe('Station Boards', function() {
                 expect(board[0]['destination']).to.have.members(['Station 3', 'Station 5']);
             });
 
-            it('should contain an array of destinations if there is two associations', () => {
+            it('should contain one destination if there is one association and the board is after the split (Train X)', () => {
+                const schedules = [
+                    {'location_records': [
+                        {'tiploc': 'ABCDEF', 'type': 'LO', location: [{'name': 'Station 1'}]},
+                        {'tiploc': 'GHIJKL', 'type': 'LI', location: [{'name': 'Station 2'}]},
+                        {'tiploc': 'LKJGFF', 'type': 'LI', location: [{'name': 'Station 6'}]},
+                        {'tiploc': 'MNOPQU', 'type': 'LT', location: [{'name': 'Station 3'}]},
+                        ],
+                    'associations': [
+                        {'location_records': [
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 4'}]},
+                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 5'}]},
+                            ],
+                        },
+                    ]}
+                ];
+    
+                const board = new StationBoard(schedules, direction.DEPARTURES, 'LKJGFF')
+                              .createBoard();
+    
+                expect(board).have.lengthOf(1);
+                expect(board[0]).to.include.any.keys('destination');
+                expect(board[0]['destination']).to.equal('Station 3');
+            });
+
+            it('should contain one destination if there is one association and the board is after the split (Train Y)', () => {
+                const schedules = [
+                    {'location_records': [
+                        {'tiploc': 'ABCDEF', 'type': 'LO', location: [{'name': 'Station 1'}]},
+                        {'tiploc': 'GHIJKL', 'type': 'LI', location: [{'name': 'Station 2'}]},
+                        {'tiploc': 'LKJGFF', 'type': 'LI', location: [{'name': 'Station 6'}]},
+                        {'tiploc': 'MNOPQU', 'type': 'LT', location: [{'name': 'Station 3'}]},
+                        ],
+                    'associations': [
+                        {'location_records': [
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 4'}]},
+                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 5'}]},
+                            ],
+                        },
+                    ]}
+                ];
+    
+                const board = new StationBoard(schedules, direction.DEPARTURES, 'ASDFGH')
+                              .createBoard();
+    
+                expect(board).have.lengthOf(1);
+                expect(board[0]).to.include.any.keys('destination');
+                expect(board[0]['destination']).to.equal('Station 5');
+            });
+
+            it('should contain an array of destinations if there is two associations and is before the split', () => {
                 const schedules = [
                     {
                         'location_records': [
@@ -180,15 +232,15 @@ describe('Station Boards', function() {
                         ],
                     'associations': [
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 4'}]},
                             {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 5'}]},
                             ],
                         },
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 2'}]},
-                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 6'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 7'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'PNFTWM', 'type': 'LI', location: [{'name': 'Station 6'}]},
+                            {'tiploc': 'WMQQBN', 'type': 'LT', location: [{'name': 'Station 7'}]},
                             ],
                         },
                         ]
@@ -213,21 +265,21 @@ describe('Station Boards', function() {
                         ],
                     'associations': [
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 4'}]},
                             {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 5'}]},
                             ],
                         },
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 2'}]},
-                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 6'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 7'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'IWNFYW', 'type': 'LI', location: [{'name': 'Station 6'}]},
+                            {'tiploc': 'TGFDOQ', 'type': 'LT', location: [{'name': 'Station 7'}]},
                             ],
                         },
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 2'}]},
-                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 8'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 9'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LO', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'PQJVBA', 'type': 'LI', location: [{'name': 'Station 8'}]},
+                            {'tiploc': 'ZMAHQE', 'type': 'LT', location: [{'name': 'Station 9'}]},
                             ],
                         },
                     ]}
@@ -327,7 +379,7 @@ describe('Station Boards', function() {
                         {'location_records': [
                             {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 4'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 5'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LT', location: [{'name': 'Station 2'}]},
                             ],
                         },
                     ]}
@@ -352,15 +404,15 @@ describe('Station Boards', function() {
                         ],
                     'associations': [
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 4'}]},
-                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 5'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'AYUWEF', 'type': 'LO', location: [{'name': 'Station 4'}]},
+                            {'tiploc': 'KJNHGE', 'type': 'LI', location: [{'name': 'Station 5'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LT', location: [{'name': 'Station 2'}]},
                             ],
                         },
                         {'location_records': [
-                            {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 6'}]},
-                            {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 7'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'XERTBS', 'type': 'LO', location: [{'name': 'Station 6'}]},
+                            {'tiploc': 'DYPUR', 'type': 'LI', location: [{'name': 'Station 7'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LT', location: [{'name': 'Station 2'}]},
                             ],
                         },
                         ]
@@ -387,19 +439,19 @@ describe('Station Boards', function() {
                         {'location_records': [
                             {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 4'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 5'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LT', location: [{'name': 'Station 2'}]},
                             ],
                         },
                         {'location_records': [
                             {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 6'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 7'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LT', location: [{'name': 'Station 2'}]},
                             ],
                         },
                         {'location_records': [
                             {'tiploc': 'QWERTY', 'type': 'LO', location: [{'name': 'Station 8'}]},
                             {'tiploc': 'ASDFGH', 'type': 'LI', location: [{'name': 'Station 9'}]},
-                            {'tiploc': 'ZXCVBN', 'type': 'LT', location: [{'name': 'Station 2'}]},
+                            {'tiploc': 'GHIJKL', 'type': 'LT', location: [{'name': 'Station 2'}]},
                             ],
                         },
                     ]}

--- a/test/stationBoard.test.js
+++ b/test/stationBoard.test.js
@@ -99,7 +99,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
 
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -115,7 +115,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
 
-                const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -136,7 +136,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -161,7 +161,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'ABCDEF')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['ABCDEF'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -188,7 +188,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'LKJGFF')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['LKJGFF'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -214,7 +214,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'ASDFGH')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['ASDFGH'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -247,7 +247,7 @@ describe('Station Boards', function() {
                     }
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -285,7 +285,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -305,7 +305,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -322,7 +322,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -339,7 +339,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -360,7 +360,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -385,7 +385,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -419,7 +419,7 @@ describe('Station Boards', function() {
                     }
                 ];
     
-                const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -457,7 +457,7 @@ describe('Station Boards', function() {
                     ]}
                 ];
     
-                const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+                const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                               .createBoard();
     
                 expect(board).have.lengthOf(1);
@@ -476,7 +476,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -493,7 +493,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -511,7 +511,7 @@ describe('Station Boards', function() {
             ];
 
 
-            const board = new StationBoard(schedules, direction.ARRIVALS, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.ARRIVALS, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -530,7 +530,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                           .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -546,7 +546,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                             .createBoard();
 
             expect(board).have.lengthOf(1);
@@ -563,7 +563,7 @@ describe('Station Boards', function() {
                 ]}
             ];
 
-            const board = new StationBoard(schedules, direction.DEPARTURES, 'GHIJKL')
+            const board = new StationBoard(schedules, direction.DEPARTURES, ['GHIJKL'])
                             .createBoard();
 
             expect(board).have.lengthOf(1);


### PR DESCRIPTION
Fixes #7 

This PR does some neat transformations on the location records. For Associations, it 'reconstructs' the full journey up until the point of activity (split/join) and then checks if the tiploc for the desired station board is in that full leg of the journey.

A bit of preemptive work to fix up #3 as it considers all TIPLOCs to the station board as arrays.